### PR TITLE
Don't mangle the original objects when deep === true

### DIFF
--- a/lib/cjson.js
+++ b/lib/cjson.js
@@ -114,6 +114,14 @@ exports.extend = (function() {
                     toString.call(args[i][key]) === obj &&
                     toString.call(target[key]) === obj) {
 
+                    // Create a shallow copy of the target[key] so obj1, obj2... are left alone,
+                    // then extend it recursively:
+                    var shallowCopy = {};
+                    Object.keys(target[key]).forEach(function (propertyName) {
+                        shallowCopy[propertyName] = target[key][propertyName];
+                    });
+                    target[key] = shallowCopy;
+
                     extend(deep, target[key], args[i][key]);
                 } else {
                     target[key] = args[i][key];


### PR DESCRIPTION
Test case:

``` javascript
var cjson = require('cjson');
var one = {a: {b: 1}},
    two = {a: {b: 2}};

console.log(cjson.extend(true, {}, one, two));
```

Output:

```
{ a: { b: 2 }}
```

... which is correct, but `one` has also been changed:

``` javascript
console.log(one);
```

Output:

```
{ a: { b: 2 }}
```
