### PR TITLE
Allow cjson.replace variables to be Objects or Arrays

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,7 +99,15 @@ exports.parse = function(str, reviver) {
  */
 exports.replace = function(str, data) {
     return str.replace(/\{\{([^}]+)\}\}/g, function(match, search) {
-        return data[search] ? data[search] : match;
+        if (data.hasOwnProperty(search)) {
+            // If the variable is an object, stringify it before replacement.
+            // The false positive of "null" is fine in this case.
+            if (typeof data[search] === 'object') {
+                return JSON.stringify(data[search]);
+            }
+            return data[search];
+        }
+        return match;
     });
 };
 

--- a/test/fixtures/conf11.json
+++ b/test/fixtures/conf11.json
@@ -1,0 +1,10 @@
+{
+    "subobject": {
+        "test": 5
+    },
+    "subarray": [
+        {
+           "foo": 7
+        }
+    ]
+}

--- a/test/fixtures/conf12.json
+++ b/test/fixtures/conf12.json
@@ -1,0 +1,8 @@
+{
+    "num": 1,
+    "str": "moo",
+    "bool": false,
+    "arr": [],
+    "obj": {},
+    "null": null
+}

--- a/test/fixtures/templates/conf11tmpl.json
+++ b/test/fixtures/templates/conf11tmpl.json
@@ -1,0 +1,4 @@
+{
+    "subobject": {{subobject}},
+    "subarray": {{subarray}}
+}

--- a/test/fixtures/templates/conf12tmpl.json
+++ b/test/fixtures/templates/conf12tmpl.json
@@ -1,0 +1,8 @@
+{
+    "num": {{num}},
+    "str": "{{str}}",
+    "bool": {{bool}},
+    "arr": {{arr}},
+    "obj": {{obj}},
+    "null": {{null}}
+}

--- a/test/test.js
+++ b/test/test.js
@@ -17,6 +17,24 @@ var data = {
     conf7: {"key": "{{root}}/src"},
     conf8: {},
     conf10: {"test":"valid JSON, except for the the hidden BOM character"},
+    conf11: {
+        "subobject": {
+            "test": 5
+        },
+        "subarray": [
+            {
+                "foo": 7
+            }
+        ]
+    },
+    conf12: {
+        "num": 1,
+        "str": "moo",
+        "bool": false,
+        "arr": [],
+        "obj": {},
+        "null": null
+    }
 };
 
 a.doesNotThrow(function() {
@@ -40,6 +58,12 @@ a.deepEqual(cjson.load(fixtures + '/conf7.json', {replace: {root: '/usr'}}), {"k
 a.deepEqual(cjson.load(fixtures + '/conf8.json'), data.conf8, 'string-like comment');
 
 a.deepEqual(cjson.load(fixtures + '/conf10.json'), data.conf10, 'BOM character');
+
+var conf11 = cjson.load(fixtures + '/conf11.json');
+a.deepEqual(cjson.load(fixtures + '/templates/conf11tmpl.json', {replace: conf11}), data.conf11, 'object and array as template variables');
+
+var conf12 = cjson.load(fixtures + '/conf12.json');
+a.deepEqual(cjson.load(fixtures + '/templates/conf12tmpl.json', {replace: conf12}), data.conf12, 'JSON types as template variables');
 
 var data1 = {
     conf1: {key: 'value'},


### PR DESCRIPTION
This allows for great composability of config files.

```
base.cjson:
{
    "opt": 3,
    "ext": {{ext}}
}

ext.cjson:
{
    "ext": {
        "more": 5
    }
}
```

Previously this was only possible by making a variable a single line string, which is not useful for big blocks.

First I went for cjson.extend to manually add sub-objects where they belong, but this quickly got messy and unclear.

Related: What do you think about an operation similar to "merge" for replace, where you give it a base and ordered replacements? It would replace and extend from last to first file to gather all variables into a final file.